### PR TITLE
Fix blocked insecure content errors

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
     <title>About Neurokernel</title>
 
     <!-- Make sure Ubuntu fonts are available -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@
     <title>Join the Neurokernel Project</title>
 
     <!-- Make sure Ubuntu fonts are available -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">

--- a/docs.html
+++ b/docs.html
@@ -12,7 +12,7 @@
     <title>Neurokernel</title>
 
     <!-- Make sure Ubuntu fonts are available -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">

--- a/faq.html
+++ b/faq.html
@@ -12,7 +12,7 @@
     <title>Frequently Asked Questions About Neurokernel</title>
 
     <!-- Make sure Ubuntu fonts are available -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <title>Neurokernel</title>
 
     <!-- Make sure Ubuntu fonts are available -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">
@@ -143,13 +143,13 @@
       <div class="bs-docs-social">
         <div class="container">
           <ul class="bs-docs-social-buttons">
-            <li><iframe src="http://ghbtns.com/github-btn.html?user=neurokernel&repo=neurokernel&type=watch&count=true"              
+            <li><iframe src="https://ghbtns.com/github-btn.html?user=neurokernel&repo=neurokernel&type=watch&count=true"              
                         allowtransparency="true" frameborder="0" scrolling="0"
                         width="110" height="20"></iframe></li>
-            <li><iframe src="http://ghbtns.com/github-btn.html?user=neurokernel&repo=neurokernel&type=fork&count=true"            
+            <li><iframe src="https://ghbtns.com/github-btn.html?user=neurokernel&repo=neurokernel&type=fork&count=true"            
                     allowtransparency="true" frameborder="0" scrolling="0" width="100"
                     height="20"></iframe></li>
-            <li><iframe src="http://ghbtns.com/github-btn.html?user=neurokernel&type=follow&count=true"                    
+            <li><iframe src="https://ghbtns.com/github-btn.html?user=neurokernel&type=follow&count=true"                    
                     allowtransparency="true" frameborder="0" scrolling="0" width="200"
                     height="20"></iframe></li>
           </ul>
@@ -170,7 +170,7 @@
 
           <div class="embed-responsive embed-responsive-4by3">
               <iframe class="embed-responsive-item" height="333" width="95%"
-              src="http://www.youtube.com/embed/fwQx1OUltx4"
+              src="https://www.youtube.com/embed/fwQx1OUltx4"
               allowfullscreen frameborder="0"></iframe>
           </div>
         </div>

--- a/people.html
+++ b/people.html
@@ -12,7 +12,7 @@
     <title>Neurokernel People</title>
 
     <!-- Make sure Ubuntu fonts are available -->
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:regular,bold&subset=Latin">
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.css" rel="stylesheet">
@@ -113,7 +113,7 @@
             </li>
             <li class="list-group-item">
 	      <div class="media">
-		<img src="http://placehold.it/100x100"
+		<img src="https://placehold.it/100x100"
 		     class="img-thumbnail img-responsive media-object custom-media-object pull-left" />
 		<div class="media-body custom-media-body">
 		  <a href="">Carlos Luna Ortiz</a><br/>


### PR DESCRIPTION
This fixes the issue #1 with insecure content errors by changing the relevant HTTP URLs to HTTPS.
They could be changed to protocol-relative URLs but for example the embedded movie:
http://www.youtube.com/embed/fwQx1OUltx4
gets redirected to HTTPS anyway, so using HTTPS in the first place avoids the unnecessary redirect.
